### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -1,4 +1,6 @@
 name: Translation Status Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ivsjsc/ivs.github.io/security/code-scanning/1](https://github.com/ivsjsc/ivs.github.io/security/code-scanning/1)

To fix this issue, you should add the `permissions` block to the workflow configuration, specifying only the minimum required permissions. Since the workflow does not perform any write operations (such as committing, creating issues, or updating pull requests), it suffices to grant read-only access to repository contents. Place the `permissions` block at the workflow root, so it applies to all jobs in the workflow unless otherwise specified. Insert the following lines after the `name` field and before the `on:` trigger event. No new methods, imports, or definitions are necessary; it's a simple edit of the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
